### PR TITLE
Fixed threaded library initialization.

### DIFF
--- a/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
+++ b/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
@@ -652,7 +652,7 @@ public class SevenZip {
 		return callNativeOpenArchive(null, inStream, new DummyOpenArchiveCallback());
 	}
 
-	private static void ensureLibraryIsInitialized() {
+	private static synchronized void ensureLibraryIsInitialized() {
 		if (autoInitializationWillOccur) {
 			autoInitializationWillOccur = false;
 			try {


### PR DESCRIPTION
Fixed the potential RuntimeException thrown from SevenZip.ensureLibraryIsInitialized() if multiple threads attempt to use
the class for the first time in parallel.