### PR TITLE
fix auto init issue when multithreading

### DIFF
--- a/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
+++ b/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
@@ -800,7 +800,6 @@ public class SevenZip {
 
     private static void ensureLibraryIsInitialized() {
         if (autoInitializationWillOccur) {
-            autoInitializationWillOccur = false;
             try {
                 initSevenZipFromPlatformJAR();
             } catch (SevenZipNativeInitializationException exception) {


### PR DESCRIPTION
In multithreading Java code, where each thread decompressing different files, the auto initialize code will throw `SevenZipJBinding wasn't initialized successfully last time.` sometimes.

The reasoning is that, for example,
- thread A enters `ensureLibraryIsInitialized()` and saw that `autoInitializationWillOccur` is `true`, so thread A enters the first if and set `autoInitializationWillOccur` to `false`. 
- while thread A hasn't done initialization, thread B also enters `ensureLibraryIsInitialized()`, but it saw that `autoInitializationWillOccur` is false, so thread B skips the first if, but saw `initializationSuccessful` is false, because thread A hasn't done initializing. 

In above scenario, thread B will throw `SevenZipJBinding wasn't initialized successfully last time.` exception.

Removing the set to false line will fix this bug since `autoInitializationWillOccur` will be set to false in synchronized method `initSevenZipFromPlatformJARIntern` anyway.