### PR TITLE
Fix hash conversion from byte[] to hex String

### DIFF
--- a/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
+++ b/jbinding-java/src/net/sf/sevenzipjbinding/SevenZip.java
@@ -629,7 +629,7 @@ public class SevenZip {
     private static String byteArrayToHex(byte[] byteArray) {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < byteArray.length; i++) {
-            stringBuilder.append(Integer.toHexString(0xFF & byteArray[i]));
+            stringBuilder.append(String.format("%1$02x", 0xFF & byteArray[i]));
         }
         return stringBuilder.toString();
     }


### PR DESCRIPTION
Closes borisbrodski#31: fix native library hash comparison, so that other processes can share the same extracted lib, instead of trying and failing to overwrite it while it is being used by another process.