### PR TITLE
Add Android JNI support

### DIFF
--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.cpp
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.cpp
@@ -12,6 +12,11 @@
  _cryptoGetTextPasswordImpl = NULL;
 
  jclass cryptoGetTextPasswordClass = initEnv->FindClass(CRYPTOGETTEXTPASSWORD_CLASS);
+ #ifdef __ANDROID_API__
+ if (cryptoGetTextPasswordClass == nullptr) {
+ cryptoGetTextPasswordClass = findClass(initEnv, CRYPTOGETTEXTPASSWORD_CLASS);
+ }
+ #endif
  FATALIF(cryptoGetTextPasswordClass == NULL,
  "Can't find class " CRYPTOGETTEXTPASSWORD_CLASS);
 
@@ -71,6 +76,9 @@ STDMETHODIMP CPPToJavaArchiveExtractCallback::GetStream(UInt32 index,
     // public SequentialOutStream getStream(int index, ExtractAskMode extractAskMode);
     jobject result = _iArchiveExtractCallback->getStream(jniEnvInstance, _javaImplementation,
             (jint) index, askExtractModeObject);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(askExtractModeObject);
+#endif
     if (jniEnvInstance.exceptionCheck()) {
         return S_FALSE;
     }
@@ -82,6 +90,9 @@ STDMETHODIMP CPPToJavaArchiveExtractCallback::GetStream(UInt32 index,
 
     CMyComPtr<ISequentialOutStream> outStreamComPtr = new CPPToJavaSequentialOutStream(
             _jbindingSession, jniEnvInstance, result);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(result);
+#endif
     *outStream = outStreamComPtr.Detach();
 
     return S_OK;
@@ -101,6 +112,9 @@ STDMETHODIMP CPPToJavaArchiveExtractCallback::PrepareOperation(Int32 askExtractM
     // public void prepareOperation(ExtractAskMode extractAskMode);
     _iArchiveExtractCallback->prepareOperation(jniEnvInstance, _javaImplementation,
             askExtractModeObject);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(askExtractModeObject);
+#endif
 
     return jniEnvInstance.exceptionCheck() ? S_FALSE : S_OK;
 }
@@ -120,6 +134,9 @@ STDMETHODIMP CPPToJavaArchiveExtractCallback::SetOperationResult(Int32 resultEOp
     // public void setOperationResult(ExtractOperationResult extractOperationResult);
     _iArchiveExtractCallback->setOperationResult(jniEnvInstance, _javaImplementation,
             resultEOperationResultObject);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(resultEOperationResultObject);
+#endif
 
     return jniEnvInstance.exceptionCheck() ? S_FALSE : S_OK;
 }

--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.h
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.h
@@ -19,6 +19,11 @@ public:
         TRACE_OBJECT_CREATION("CPPToJavaArchiveExtractCallback")
 
         jclass cryptoGetTextPasswordClass = initEnv->FindClass(CRYPTOGETTEXTPASSWORD_CLASS);
+#ifdef __ANDROID_API__
+        if (cryptoGetTextPasswordClass == nullptr) {
+            cryptoGetTextPasswordClass = findClass(initEnv, CRYPTOGETTEXTPASSWORD_CLASS);
+        }
+#endif
         FATALIF(cryptoGetTextPasswordClass == NULL,
                 "Can't find class " CRYPTOGETTEXTPASSWORD_CLASS);
 

--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveOpenVolumeCallback.cpp
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveOpenVolumeCallback.cpp
@@ -23,11 +23,17 @@ STDMETHODIMP CPPToJavaArchiveOpenVolumeCallback::GetProperty(PROPID propID, PROP
 
     jobject result = _iArchiveOpenVolumeCallback->getProperty(jniEnvInstance, _javaImplementation,
             propIDObject);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(propIDObject);
+#endif
     if (jniEnvInstance.exceptionCheck()) {
         return S_FALSE;
     }
 
     ObjectToPropVariant(jniEnvInstance, result, value);
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteLocalRef(result);
+#endif
 
     return S_OK;
 }
@@ -56,6 +62,9 @@ STDMETHODIMP CPPToJavaArchiveOpenVolumeCallback::GetStream(const wchar_t *name,
         if (inStreamImpl) {
             CPPToJavaInStream * newInStream = new CPPToJavaInStream(_jbindingSession, jniEnvInstance,
                     inStreamImpl);
+#ifdef __ANDROID_API__
+            jniEnvInstance->DeleteLocalRef(inStreamImpl);
+#endif
 
             CMyComPtr<IInStream> inStreamComPtr = newInStream;
             *inStream = inStreamComPtr.Detach();

--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveUpdateCallback.cpp
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveUpdateCallback.cpp
@@ -85,6 +85,9 @@ UInt32 *indexInArchive /* -1 if there is no in archive, or if doesn't matter */
                 if (jniEnvInstance.exceptionCheck()) {
                     return S_FALSE;
                 }
+#ifdef __ANDROID_API__
+                jniEnvInstance->DeleteLocalRef(newDataObject);
+#endif
             } else {
                 jniEnvInstance.reportError("The attribute 'updateNewData' of the corresponding IOutItem* class shouldn't be null (index=%i)", index);
                 return S_FALSE;
@@ -110,6 +113,9 @@ UInt32 *indexInArchive /* -1 if there is no in archive, or if doesn't matter */
                 if (jniEnvInstance.exceptionCheck()) {
                     return S_FALSE;
                 }
+#ifdef __ANDROID_API__
+                jniEnvInstance->DeleteLocalRef(newPropertiesObject);
+#endif
             } else {
                 jniEnvInstance.reportError("The attribute 'updateNewProperties' of the corresponding IOutItem* class shouldn't be null (index=%i)", index);
                 return S_FALSE;
@@ -135,6 +141,9 @@ UInt32 *indexInArchive /* -1 if there is no in archive, or if doesn't matter */
                 if (jniEnvInstance.exceptionCheck()) {
                     return S_FALSE;
                 }
+#ifdef __ANDROID_API__
+                jniEnvInstance->DeleteLocalRef(oldArchiveItemIndexObject);
+#endif
             } else {
                 *indexInArchive = (UInt32) -1;
             }
@@ -390,6 +399,11 @@ STDMETHODIMP CPPToJavaArchiveUpdateCallback::GetStream(UInt32 index, ISequential
     if (inStreamImpl) {
 
         jclass inStreamInterface = jniEnvInstance->FindClass(INSTREAM_CLASS);
+#ifdef __ANDROID_API__
+        if (inStreamInterface == nullptr) {
+            inStreamInterface = findClass(jniEnvInstance, INSTREAM_CLASS);
+        }
+#endif
         FATALIF(!inStreamInterface, "Class " INSTREAM_CLASS " not found");
 
         if (jniEnvInstance->IsInstanceOf(inStreamImpl, inStreamInterface)) {

--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveUpdateCallback.h
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveUpdateCallback.h
@@ -40,8 +40,17 @@ public:
 
         _isICryptoGetTextPasswordImplemented = jni::ICryptoGetTextPassword::_isInstance(initEnv, _javaImplementation);
 		JNIEnvInstance jniEnvInstance(_jbindingSession);
+#ifdef __ANDROID_API__
+        _outArchive = jniEnvInstance->NewGlobalRef(outArchive);
+#endif
     }
 
+#ifdef __ANDROID_API__
+    ~CPPToJavaArchiveUpdateCallback() {
+        JNIEnvInstance jniEnvInstance(_jbindingSession);
+        jniEnvInstance->DeleteGlobalRef(_outArchive);
+    }
+#endif
     STDMETHOD(GetUpdateItemInfo)(UInt32 index, Int32 *newData, /*1 - new data, 0 - old data */
     Int32 *newProperties, /* 1 - new properties, 0 - old properties */
     UInt32 *indexInArchive /* -1 if there is no in archive, or if doesn't matter */

--- a/jbinding-cpp/CodecTools.cpp
+++ b/jbinding-cpp/CodecTools.cpp
@@ -54,6 +54,9 @@ static int getIndexByName(JNIEnv * env, UString & formatNameString) {
 void CodecTools::getArchiveFormatName(JNIEnv * env, jobject archiveFormat, UString & formatNameString) {
     jstring formatName = jni::ArchiveFormat::methodName_Get(env, archiveFormat);
     formatNameString = FromJChar(env, formatName);
+#ifdef __ANDROID_API__
+	env->DeleteLocalRef(formatName);
+#endif
 }
 
 int CodecTools::getArchiveFormatIndex(JNIEnv * env, jobject archiveFormat) {

--- a/jbinding-cpp/Debug.h
+++ b/jbinding-cpp/Debug.h
@@ -116,6 +116,9 @@ inline std::ostream & operator<<(JOut jout, jobject object) {
     jclass objectClass = jout._env->GetObjectClass(object);
     MY_ASSERT(objectClass)
     jmethodID id = jout._env->GetMethodID(objectClass, "toString", "()Ljava/lang/String;");
+#ifdef __ANDROID_API__
+    jout._env->DeleteLocalRef(objectClass);
+#endif
     jstring string = (jstring) jout._env->CallObjectMethod(object, id);
     MY_ASSERT(string)//FATALIF(string == NULL, "CallNonvirtualObjectMethod() returns NULL");
 
@@ -137,6 +140,9 @@ inline std::ostream & operator<<(JOut jout, jclass clazz) {
 
     jstring string = (jstring) jout._env->CallNonvirtualObjectMethod(clazz, classClass, id);
     MY_ASSERT(string)//FATALIF(string == NULL, "CallNonvirtualObjectMethod() returns NULL");
+#ifdef __ANDROID_API__
+    jout._env->DeleteLocalRef(classClass);
+#endif
 
     std::ostream & stream = jout << string;
     jout._env->DeleteLocalRef(string);

--- a/jbinding-cpp/JBindingTools.cpp
+++ b/jbinding-cpp/JBindingTools.cpp
@@ -9,6 +9,10 @@
 
 #include "JBindingTools.h"
 
+#ifdef __ANDROID_API__
+#include "JavaStatInfos/JavaPackageSevenZip.h"
+#endif
+
 JT_BEGIN_CLASS("net/sf/sevenzipjbinding", SevenZipException)
 /*    */JT_CLASS_VIRTUAL_METHOD_OBJECT("Ljava/lang/Throwable;", initCause, JT_THROWABLE(cause,_))
 /*    */JT_CLASS_CONSTRUCTOR(JT_STRING(message, _))
@@ -32,6 +36,101 @@ static struct {
                               {E_OUTOFMEMORY, "Out of memory"}, // ((HRESULT)0x8007000EL)
                               {E_INVALIDARG, "Invalid argument"}, // ((HRESULT)0x80070057L)
                               {0, NULL}, };
+
+#ifdef __ANDROID_API__
+jmethodID JBindingSession::_classLoaderID;
+std::map<const char*, jobject> JBindingSession::_classLoaderObjects;
+
+static jobject addClassLoaderObject(JNIEnv* env, const char* name) {
+    jclass clazz = env->FindClass(name);
+    jclass objectClass = env->GetObjectClass(clazz);
+    jmethodID classLoaderID = env->GetMethodID(objectClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+    env->DeleteLocalRef(objectClass);
+    jobject classLoaderObject = env->CallObjectMethod(clazz, classLoaderID);
+    env->DeleteLocalRef(clazz);
+    jobject classObject = env->NewGlobalRef(classLoaderObject);
+    env->DeleteLocalRef(classLoaderObject);
+    return classObject;
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *pjvm, void *reserved) {
+    JNIEnv* env = nullptr;
+    if (pjvm->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_OK) {
+        jclass classLoaderClass = env->FindClass("java/lang/ClassLoader");
+        JBindingSession::_classLoaderID = env->GetMethodID(classLoaderClass, "findClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+        env->DeleteLocalRef(classLoaderClass);
+
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(PROPERTYINFO_CLASS, addClassLoaderObject(env, PROPERTYINFO_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(PROPID_CLASS, addClassLoaderObject(env, PROPID_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEQUENTIALOUTSTREAM_CLASS, addClassLoaderObject(env, SEQUENTIALOUTSTREAM_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEQUENTIALINSTREAM_CLASS, addClassLoaderObject(env, SEQUENTIALINSTREAM_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(INSTREAM_CLASS, addClassLoaderObject(env, INSTREAM_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(CRYPTOGETTEXTPASSWORD_CLASS, addClassLoaderObject(env, CRYPTOGETTEXTPASSWORD_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(ARCHIVEOPENVOLUMECALLBACK_CLASS, addClassLoaderObject(env, ARCHIVEOPENVOLUMECALLBACK_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(EXTRACTASKMODE_CLASS, addClassLoaderObject(env, EXTRACTASKMODE_CLASS)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(EXTRACTOPERATIONRESULT_CLASS, addClassLoaderObject(env, EXTRACTOPERATIONRESULT_CLASS)));
+
+//        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_PROP_ID, addClassLoaderObject(env, JAVA_PROP_ID)));
+//        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_EXTRACT_ASK_MODE, addClassLoaderObject(env, JAVA_EXTRACT_ASK_MODE)));
+//        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_EXTRACT_OPERATION_RESULT, addClassLoaderObject(env, JAVA_EXTRACT_OPERATION_RESULT)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_IIN_ARCHIVE, addClassLoaderObject(env, JAVA_IIN_ARCHIVE)));
+//        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_IIN_STREAM, addClassLoaderObject(env, JAVA_IIN_STREAM)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_ISEQUENTIAL_IN_STREAM, addClassLoaderObject(env, JAVA_ISEQUENTIAL_IN_STREAM)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_ISEQUENTIAL_OUT_STREAM, addClassLoaderObject(env, JAVA_ISEQUENTIAL_OUT_STREAM)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_IOUT_ARCHIVE, addClassLoaderObject(env, JAVA_IOUT_ARCHIVE)));
+//        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_IOUT_ITEM_CALLBACK_BASE, addClassLoaderObject(env, JAVA_IOUT_ITEM_CALLBACK_BASE)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_ARCHIVE_FORMAT, addClassLoaderObject(env, JAVA_ARCHIVE_FORMAT)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_OUT_ITEM_FACTORY, addClassLoaderObject(env, JAVA_OUT_ITEM_FACTORY)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_OUT_ITEM, addClassLoaderObject(env, JAVA_OUT_ITEM)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_IOUT_ITEM_BASE, addClassLoaderObject(env, JAVA_IOUT_ITEM_BASE)));
+
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/IArchiveOpenCallback", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/IArchiveOpenCallback")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/IProgress", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/IProgress")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/IArchiveExtractCallback", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/IArchiveExtractCallback")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/IOutStream", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/IOutStream")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/ISeekableStream", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/ISeekableStream")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE"/IOutCreateCallback", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE"/IOutCreateCallback")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE_IMPL"/InArchiveImpl", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE_IMPL"/InArchiveImpl")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(SEVEN_ZIP_PACKAGE_IMPL"/OutArchiveImpl", addClassLoaderObject(env, SEVEN_ZIP_PACKAGE_IMPL"/OutArchiveImpl")));
+
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_OBJECT, addClassLoaderObject(env, JAVA_OBJECT)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_BYTE, addClassLoaderObject(env, JAVA_BYTE)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_CHARACTER, addClassLoaderObject(env, JAVA_CHARACTER)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_SHORT, addClassLoaderObject(env, JAVA_SHORT)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_NUMBER, addClassLoaderObject(env, JAVA_NUMBER)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_INTEGER, addClassLoaderObject(env, JAVA_INTEGER)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_LONG, addClassLoaderObject(env, JAVA_LONG)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_FLOAT, addClassLoaderObject(env, JAVA_FLOAT)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_DOUBLE, addClassLoaderObject(env, JAVA_DOUBLE)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_BOOLEAN, addClassLoaderObject(env, JAVA_BOOLEAN)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_STRING, addClassLoaderObject(env, JAVA_STRING)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_THROWABLE, addClassLoaderObject(env, JAVA_THROWABLE)));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair(JAVA_DATE, addClassLoaderObject(env, JAVA_DATE)));
+
+#ifdef NATIVE_JUNIT_TEST_SUPPORT
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jbindingtools/Callback1", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jbindingtools/Callback1")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jbindingtools/JBindingTest", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jbindingtools/JBindingTest")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jbindingtools/ExceptionHandlingTest", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jbindingtools/ExceptionHandlingTest")));
+
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jnitools/JTestAbstractClass", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jnitools/JTestAbstractClass")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jnitools/JTestFinalClass", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jnitools/JTestFinalClass")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jnitools/Interface1", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jnitools/Interface1")));
+        JBindingSession::_classLoaderObjects.insert(std::make_pair("net/sf/sevenzipjbinding/junit/jnitools/ParamSpecTest", addClassLoaderObject(env, "net/sf/sevenzipjbinding/junit/jnitools/ParamSpecTest")));
+#endif
+    }
+    return JNI_VERSION_1_6;
+}
+
+jclass findClass(JNIEnv* env, const char* name) {
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+    jstring string = env->NewStringUTF(name);
+    jclass clazz = static_cast<jclass>(env->CallObjectMethod(JBindingSession::_classLoaderObjects.at(name), JBindingSession::_classLoaderID, string));
+    env->DeleteLocalRef(string);
+    return clazz;
+}
+#endif
 
 /*
  * Return error message from error code
@@ -144,6 +243,9 @@ JNINativeCallContext::~JNINativeCallContext() {
             }
             sevenZipException = static_cast<jthrowable> (jni::SevenZipException::newInstance(
                     _jniCallOriginalEnv, message));
+#ifdef __ANDROID_API__
+            _jniCallOriginalEnv->DeleteLocalRef(message);
+#endif
             assertNoExceptionOnJniCallOriginalEnv();
 
             if (_firstThrownException) {

--- a/jbinding-cpp/JNITools.cpp
+++ b/jbinding-cpp/JNITools.cpp
@@ -35,11 +35,21 @@ static void localinit(JNIEnv * env) {
     }
 
     //	g_NumberClass = env->FindClass(JAVA_NUMBER);
+    //	#ifdef __ANDROID_API__
+    //	if (g_NumberClass == nullptr) {
+    //	g_NumberClass = findClass(env, JAVA_NUMBER);
+    //	}
+    //	#endif
     //	FATALIF(g_NumberClass == NULL, "Can't find Number class");
     //	g_NumberClass = (jclass) env->NewGlobalRef(g_NumberClass);
 
     // class: Integer
     g_IntegerClass = env->FindClass(JAVA_INTEGER);
+#ifdef __ANDROID_API__
+    if (g_IntegerClass == nullptr) {
+        g_IntegerClass = findClass(env, JAVA_INTEGER);
+    }
+#endif
     FATALIF(g_IntegerClass == NULL, "Can't find Integer class");
     g_IntegerClass = (jclass) env->NewGlobalRef(g_IntegerClass);
 
@@ -51,6 +61,11 @@ static void localinit(JNIEnv * env) {
 
     // class: Long
     g_LongClass = env->FindClass(JAVA_LONG);
+#ifdef __ANDROID_API__
+    if (g_LongClass == nullptr) {
+        g_LongClass = findClass(env, JAVA_LONG);
+    }
+#endif
     FATALIF(g_LongClass == NULL, "Can't find Long class");
     g_LongClass = (jclass) env->NewGlobalRef(g_LongClass);
     g_LongValueOf = env->GetStaticMethodID(g_LongClass, "valueOf", "(J)L" JAVA_LONG ";");
@@ -61,12 +76,22 @@ static void localinit(JNIEnv * env) {
 
     // class: Double
     g_DoubleClass = env->FindClass(JAVA_DOUBLE);
+#ifdef __ANDROID_API__
+    if (g_DoubleClass == nullptr) {
+        g_DoubleClass = findClass(env, JAVA_DOUBLE);
+    }
+#endif
     FATALIF(g_DoubleClass == NULL, "Can't find Double class");
     g_DoubleClass = (jclass) env->NewGlobalRef(g_DoubleClass);
     g_DoubleValueOf = env->GetStaticMethodID(g_DoubleClass, "valueOf", "(D)Ljava/lang/Double;");
     FATALIF(g_DoubleValueOf == NULL, "Can't find Double.valueOf() method");
 
     g_BooleanClass = env->FindClass(JAVA_BOOLEAN);
+#ifdef __ANDROID_API__
+    if (g_BooleanClass == nullptr) {
+        g_BooleanClass = findClass(env, JAVA_BOOLEAN);
+    }
+#endif
     FATALIF(g_BooleanClass == NULL, "Can't find Boolean class");
 
     g_BooleanClass = (jclass) env->NewGlobalRef(g_BooleanClass);
@@ -78,10 +103,20 @@ static void localinit(JNIEnv * env) {
 
     // class: String
     g_StringClass = env->FindClass(JAVA_STRING);
+#ifdef __ANDROID_API__
+    if (g_StringClass == nullptr) {
+        g_StringClass = findClass(env, JAVA_STRING);
+    }
+#endif
     FATALIF(g_StringClass == NULL, "Can't find String class");
     g_StringClass = (jclass) env->NewGlobalRef(g_StringClass);
 
     g_DateClass = env->FindClass("java/util/Date");
+#ifdef __ANDROID_API__
+    if (g_DateClass == nullptr) {
+        g_DateClass = findClass(env, "java/util/Date");
+    }
+#endif
     FATALIF(g_DateClass == NULL, "Can't find java.util.Date class");
     g_DateClass = (jclass) env->NewGlobalRef(g_DateClass);
 
@@ -100,12 +135,18 @@ char * GetJavaClassName(JNIEnv * env, jclass clazz, char * buffer, size_t size) 
     jmethodID id = env->GetMethodID(reflectionClass, "getName", "()Ljava/lang/String;");
     FATALIF(id == NULL, "Method Class.getName() can't be found");
 
-    jstring string = (jstring) env->CallNonvirtualObjectMethod(clazz, reflectionClass, id);
+    jobject string = env->CallNonvirtualObjectMethod(clazz, reflectionClass, id);
     FATALIF(string == NULL, "CallNonvirtualObjectMethod() returns NULL");
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(reflectionClass);
+#endif
 
-    const char * cstr = env->GetStringUTFChars(string, NULL);
+    const char * cstr = env->GetStringUTFChars((jstring) string, NULL);
     strncpy(buffer, cstr, size);
-    env->ReleaseStringUTFChars(string, cstr);
+    env->ReleaseStringUTFChars((jstring) string, cstr);
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(string);
+#endif
 
     return buffer;
 }
@@ -135,6 +176,9 @@ void SetLongAttribute(JNIEnv * env, jobject object, const char * attribute, jlon
     jfieldID fieldID = env->GetFieldID(clazz, attribute, "J");
     FATALIF2(fieldID == NULL, "Field '%s' in the class '%s' was not found", attribute,
             GetJavaClassName(env, clazz, classname, sizeof(classname)));
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(clazz);
+#endif
 
     env->SetLongField(object, fieldID, value);
 }

--- a/jbinding-cpp/JavaToCPP/JavaToCPPInArchiveImpl.cpp
+++ b/jbinding-cpp/JavaToCPP/JavaToCPPInArchiveImpl.cpp
@@ -266,6 +266,9 @@ JBINDING_JNIEXPORT jobject JNICALL Java_net_sf_sevenzipjbinding_impl_InArchiveIm
 
     jni::PropertyInfo::propID_Set(env, propertInfo, propIDObject);
     jni::PropertyInfo::name_Set(env, propertInfo, javaName);
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(javaName);
+#endif
     jni::PropertyInfo::varType_Set(env, propertInfo, javaType);
 
     return propertInfo;
@@ -471,6 +474,9 @@ JBINDING_JNIEXPORT jobject JNICALL Java_net_sf_sevenzipjbinding_impl_InArchiveIm
 
     jni::PropertyInfo::propID_Set(env, propertInfo, propIDObject);
     jni::PropertyInfo::name_Set(env, propertInfo, javaName);
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(javaName);
+#endif
     jni::PropertyInfo::varType_Set(env, propertInfo, javaType);
 
     return propertInfo;

--- a/jbinding-cpp/JavaToCPP/JavaToCPPSevenZip.cpp
+++ b/jbinding-cpp/JavaToCPP/JavaToCPPSevenZip.cpp
@@ -296,6 +296,9 @@ JBINDING_JNIEXPORT jobject JNICALL Java_net_sf_sevenzipjbinding_SevenZip_nativeO
 
     jstring jstringFormatNameString = ToJChar(formatNameString).toNewString(env);
     jni::InArchiveImpl::setArchiveFormat(env, inArchiveImplObject, jstringFormatNameString);
+#ifdef __ANDROID_API__
+    env->DeleteLocalRef(jstringFormatNameString);
+#endif
     if (jniEnvInstance.exceptionCheck()) {
         archive->Close();
         deleteInErrorCase.setErrorCase();

--- a/jbinding-cpp/UniversalArchiveOpenCallback.cpp
+++ b/jbinding-cpp/UniversalArchiveOpenCallback.cpp
@@ -17,10 +17,20 @@ void UniversalArchiveOpencallback::Init(JBindingSession & jbindingSession, JNIEn
     _simulateArchiveOpenVolumeCallback = false;
 
     jclass cryptoGetTextPasswordClass = initEnv->FindClass(CRYPTOGETTEXTPASSWORD_CLASS);
+#ifdef __ANDROID_API__
+    if (cryptoGetTextPasswordClass == nullptr) {
+        cryptoGetTextPasswordClass = findClass(initEnv, CRYPTOGETTEXTPASSWORD_CLASS);
+    }
+#endif
     FATALIF(cryptoGetTextPasswordClass == NULL,
             "Can't find class " CRYPTOGETTEXTPASSWORD_CLASS);
 
     jclass archiveOpenVolumeCallbackClass = initEnv->FindClass(ARCHIVEOPENVOLUMECALLBACK_CLASS);
+#ifdef __ANDROID_API__
+    if (archiveOpenVolumeCallbackClass == nullptr) {
+        archiveOpenVolumeCallbackClass = findClass(initEnv, ARCHIVEOPENVOLUMECALLBACK_CLASS);
+    }
+#endif
     FATALIF(cryptoGetTextPasswordClass == NULL,
             "Can't find class " ARCHIVEOPENVOLUMECALLBACK_CLASS);
 

--- a/test/CTests/JBindingTest.cpp
+++ b/test/CTests/JBindingTest.cpp
@@ -186,7 +186,10 @@ Java_net_sf_sevenzipjbinding_junit_jbindingtools_ExceptionHandlingTest_callRecur
     JBindingSession jbindingSession(env);
     JNINativeCallContext jniNativeCallContext(jbindingSession, env);
     JNIEnvInstance jniEnvInstance(jbindingSession, jniNativeCallContext, env);
+#ifdef __ANDROID_API__
+    jstring _path = (jstring) jniEnvInstance->NewGlobalRef(path);
 
+#endif
     std::stringstream sstream;
 
     bool error = false;
@@ -195,8 +198,13 @@ Java_net_sf_sevenzipjbinding_junit_jbindingtools_ExceptionHandlingTest_callRecur
         sstream << "(";
     }
     for (int i = 0; i < width; i++) {
+#ifdef __ANDROID_API__
+        jstring value = jni::ExceptionHandlingTest::recursiveCallbackMethod(jniEnvInstance, _path, depth,
+                width, mtwidth, useException, customErrorMessage, i, -1);
+#else
         jstring value = jni::ExceptionHandlingTest::recursiveCallbackMethod(jniEnvInstance, path, depth,
                 width, mtwidth, useException, customErrorMessage, i, -1);
+#endif
         error |= jniEnvInstance.exceptionCheck();
 
         if (i) {
@@ -219,7 +227,11 @@ Java_net_sf_sevenzipjbinding_junit_jbindingtools_ExceptionHandlingTest_callRecur
             parameters[i]._threadHelper = &threadHelper;
             parameters[i]._jbindingSession = &jbindingSession;
             parameters[i]._thiz = thiz;
+#ifdef __ANDROID_API__
+            parameters[i]._path = _path;
+#else
             parameters[i]._path = path;
+#endif
             parameters[i]._depth = depth;
             parameters[i]._width = width;
             parameters[i]._mtwidth = mtwidth;
@@ -269,9 +281,15 @@ Java_net_sf_sevenzipjbinding_junit_jbindingtools_ExceptionHandlingTest_callRecur
                 jniEnvInstance.reportError("Following error reports should be ignored!");
             }
         }
+#ifdef __ANDROID_API__
+        jniEnvInstance->DeleteGlobalRef(_path);
+#endif
         return NULL;
     }
 
+#ifdef __ANDROID_API__
+    jniEnvInstance->DeleteGlobalRef(_path);
+#endif
     return env->NewStringUTF(sstream.str().c_str());
 }
 


### PR DESCRIPTION
For review. Please update as needed.
`DeleteLocalRef()` calls are required for Android devices. Would suggest these to JAR based builds too, unless this breaks things.