### PR TITLE
Add Android unit test support

### DIFF
--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/ExtractFileAbstractTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/ExtractFileAbstractTest.java
@@ -305,9 +305,9 @@ public abstract class ExtractFileAbstractTest extends JUnitNativeTestBase<Extrac
                     + testFileExt
                     + "." + compressionIndex + "." + extention + context.volumeArchivePostfix;
 
-            if (!new File(archiveFilename).exists() && extention.contains("part1.rar")) {
+            if ((TestBase.getFile(archiveFilename + (usingZippedTestArchive() ? ".zip" : "")) == null || !new File(TestBase.getFile(archiveFilename + (usingZippedTestArchive() ? ".zip" : ""))).exists()) && extention.contains("part1.rar")) {
                 archiveFilename = archiveFilename.replace("part1.rar", "part01.rar");
-                if (!new File(archiveFilename).exists()) {
+                if (TestBase.getFile(archiveFilename + (usingZippedTestArchive() ? ".zip" : "")) == null || !new File(TestBase.getFile(archiveFilename + (usingZippedTestArchive() ? ".zip" : ""))).exists()) {
                     archiveFilename = archiveFilename.replace("part01.rar", "rar");
                 }
             }
@@ -322,10 +322,10 @@ public abstract class ExtractFileAbstractTest extends JUnitNativeTestBase<Extrac
             RandomAccessFile randomAccessFile = null;
             try {
                 if (usingZippedTestArchive()) {
-                    ZipFile zipFile = new ZipFile(new File(archiveFilename + ".zip"));
+                    ZipFile zipFile = new ZipFile(new File(TestBase.getFile(archiveFilename + ".zip")));
                     randomAccessFileInStream = new ZipInStream(zipFile, zipFile.entries().nextElement());
                 } else {
-                    randomAccessFile = new RandomAccessFile(archiveFilename, "r");
+                    randomAccessFile = new RandomAccessFile(TestBase.getFile(archiveFilename), "r");
                     randomAccessFileInStream = new RandomAccessFileInStream(randomAccessFile);
                 }
                 volumeArchiveOpenCallback = null;
@@ -569,14 +569,19 @@ public abstract class ExtractFileAbstractTest extends JUnitNativeTestBase<Extrac
 
         public IInStream getStream(String filename) {
             try {
-				String fullfilename = new File(currentDir, new File(filename).getName()).getCanonicalPath();
+				String fullfilename;
+				if (System.getProperty("java.vendor", "unknown").equals("The Android Project")) {
+					fullfilename = currentDir + File.separatorChar + new File(filename).getName();
+				} else {
+					fullfilename = new File(currentDir, new File(filename).getName()).getCanonicalPath();
+				}
 				currentFilename = fullfilename;
 				randomAccessFile = randomAccessFileMap.get(fullfilename);
                 if (randomAccessFile != null) {
                     randomAccessFile.seek(0);
                     return new RandomAccessFileInStream(randomAccessFile);
                 }
-				randomAccessFile = new RandomAccessFile(fullfilename, "r");
+				randomAccessFile = new RandomAccessFile(TestBase.getFile(fullfilename), "r");
 				randomAccessFileMap.put(fullfilename, randomAccessFile);
                 return new RandomAccessFileInStream(randomAccessFile);
             } catch (FileNotFoundException fileNotFoundException) {

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/CallMethodsOnClosedInStreamTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/CallMethodsOnClosedInStreamTest.java
@@ -13,6 +13,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 
 public class CallMethodsOnClosedInStreamTest extends JUnitNativeTestBase<VoidContext> {
@@ -185,7 +186,7 @@ public class CallMethodsOnClosedInStreamTest extends JUnitNativeTestBase<VoidCon
     private void testWithMethod(InArchiveMethodCall call) throws Exception {
         RandomAccessFile randomAccessFile = null;
 
-        randomAccessFile = new RandomAccessFile("testdata/bug/TarArchiveWith7zInside.tar", "r");
+        randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/TarArchiveWith7zInside.tar"), "r");
         addCloseable(randomAccessFile);
 
         final IInArchive inArchive = SevenZip.openInArchive(null, new RandomAccessFileInStream(randomAccessFile));

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/CallMethodsOnClosedOutStreamTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/CallMethodsOnClosedOutStreamTest.java
@@ -16,6 +16,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 
 public class CallMethodsOnClosedOutStreamTest extends JUnitNativeTestBase<VoidContext> {
@@ -60,7 +61,7 @@ public class CallMethodsOnClosedOutStreamTest extends JUnitNativeTestBase<VoidCo
     private void testUpdateWithMethod(OutUpdateArchiveMethodCall call) throws Exception {
         RandomAccessFile randomAccessFile = null;
 
-        randomAccessFile = new RandomAccessFile("testdata/bug/TarArchiveWith7zInside.tar", "r");
+        randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/TarArchiveWith7zInside.tar"), "r");
         addCloseable(randomAccessFile);
 
         final IInArchive inArchive = SevenZip.openInArchive(null, new RandomAccessFileInStream(randomAccessFile));

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/OpenMultipartCabWithNonVolumedCallbackTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/OpenMultipartCabWithNonVolumedCallbackTest.java
@@ -18,6 +18,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 
 public class OpenMultipartCabWithNonVolumedCallbackTest extends JUnitNativeTestBase<VoidContext> {
@@ -29,7 +30,7 @@ public class OpenMultipartCabWithNonVolumedCallbackTest extends JUnitNativeTestB
         public IInStream getStream(String filename) throws SevenZipException {
             RandomAccessFile randomAccessFile;
             try {
-                randomAccessFile = new RandomAccessFile(PATH_TO_ARCHIVES + filename, "r");
+                randomAccessFile = new RandomAccessFile(TestBase.getFile(PATH_TO_ARCHIVES + filename), "r");
                 assertNotNull(randomAccessFile);
             } catch (FileNotFoundException e) {
                 throw new SevenZipException(e);
@@ -72,7 +73,7 @@ public class OpenMultipartCabWithNonVolumedCallbackTest extends JUnitNativeTestB
         IInArchive inArchive = null;
         Throwable throwable = null;
         try {
-            RandomAccessFile randomAccessFile = new RandomAccessFile(PATH_TO_ARCHIVES + DISK1_FILE, "r");
+            RandomAccessFile randomAccessFile = new RandomAccessFile(TestBase.getFile(PATH_TO_ARCHIVES + DISK1_FILE), "r");
             assertNotNull(randomAccessFile);
             try {
                 inArchive = SevenZip.openInArchive(archiveType, new RandomAccessFileInStream(randomAccessFile),

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/RarPasswordToLongCrash.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/RarPasswordToLongCrash.java
@@ -6,6 +6,7 @@ import net.sf.sevenzipjbinding.ArchiveFormat;
 import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 import org.junit.Test;
 
@@ -19,7 +20,7 @@ public class RarPasswordToLongCrash {
 
         Throwable throwable = null;
         try {
-            randomAccessFile = new RandomAccessFile("testdata/bug/RAR archive Crash (over 30 char password).rar", "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/RAR archive Crash (over 30 char password).rar"), "r");
             inArchive = SevenZip.openInArchive(ArchiveFormat.RAR, new RandomAccessFileInStream(randomAccessFile),
                     PASSWORD);
         } catch (Throwable e) {

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/SevenZipInTar.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/SevenZipInTar.java
@@ -10,6 +10,7 @@ import net.sf.sevenzipjbinding.ArchiveFormat;
 import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 public class SevenZipInTar {
 
@@ -20,7 +21,7 @@ public class SevenZipInTar {
 
         Throwable throwable = null;
         try {
-            randomAccessFile = new RandomAccessFile("testdata/bug/TarArchiveWith7zInside.tar", "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/TarArchiveWith7zInside.tar"), "r");
             inArchive = SevenZip.openInArchive(null, new RandomAccessFileInStream(randomAccessFile));
             assertEquals(ArchiveFormat.TAR, inArchive.getArchiveFormat());
             assertEquals(1, inArchive.getNumberOfItems());

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/Ticket18NullAsPassword.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/Ticket18NullAsPassword.java
@@ -15,6 +15,7 @@ import net.sf.sevenzipjbinding.ISequentialOutStream;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 import org.junit.Test;
 
@@ -128,7 +129,7 @@ public class Ticket18NullAsPassword {
 
         Throwable throwable = null;
         try {
-            randomAccessFile = new RandomAccessFile("testdata/bug/Ticket19-passh.rar", "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/Ticket19-passh.rar"), "r");
             if (withCallback) {
                 inArchive = SevenZip.openInArchive(ArchiveFormat.RAR, new RandomAccessFileInStream(randomAccessFile),
                         new ArchiveOpenCryptoCallback(password));
@@ -168,7 +169,7 @@ public class Ticket18NullAsPassword {
 
         Throwable throwable = null;
         try {
-            randomAccessFile = new RandomAccessFile("testdata/bug/Ticket19-pass.rar", "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/Ticket19-pass.rar"), "r");
             inArchive = SevenZip.openInArchive(ArchiveFormat.RAR, new RandomAccessFileInStream(randomAccessFile));
 
             ExtractOperationResult extractOperationResult;

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/WrongCRCGetterInSimpleInterface.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/bug/WrongCRCGetterInSimpleInterface.java
@@ -9,6 +9,7 @@ import net.sf.sevenzipjbinding.ArchiveFormat;
 import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.simple.ISimpleInArchiveItem;
 
 import org.junit.Test;
@@ -22,7 +23,7 @@ public class WrongCRCGetterInSimpleInterface {
 
         Throwable throwable = null;
         try {
-            randomAccessFile = new RandomAccessFile("testdata/bug/wrong_crc_getter_in_simple_interface.7z", "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/bug/wrong_crc_getter_in_simple_interface.7z"), "r");
             inArchive = SevenZip.openInArchive(ArchiveFormat.SEVEN_ZIP, new RandomAccessFileInStream(randomAccessFile));
             ISimpleInArchiveItem[] archiveItems = inArchive.getSimpleInterface().getArchiveItems();
             assertEquals(2, archiveItems.length);

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/encoding/UnicodeFilenamesInArchive.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/encoding/UnicodeFilenamesInArchive.java
@@ -17,6 +17,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 import net.sf.sevenzipjbinding.simple.ISimpleInArchive;
 import net.sf.sevenzipjbinding.simple.ISimpleInArchiveItem;
@@ -42,8 +43,8 @@ public class UnicodeFilenamesInArchive extends JUnitNativeTestBase<VoidContext> 
 
         log("Testing for " + archiveFormat);
         try {
-            randomAccessFile = new RandomAccessFile("testdata/encoding/unicode_file_names."
-                    + archiveFormat.getMethodName().toLowerCase(), "r");
+            randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/encoding/unicode_file_names."
+                    + archiveFormat.getMethodName().toLowerCase()), "r");
             inArchive = SevenZip.openInArchive(archiveFormat, new RandomAccessFileInStream(randomAccessFile));
             ISimpleInArchive simpleInterface = inArchive.getSimpleInterface();
             assertEquals(2, simpleInterface.getNumberOfItems());

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/InitializationDoesNotVerifyArtifactsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/InitializationDoesNotVerifyArtifactsTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipNativeInitializationException;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 /**
  * Tests, that 7-Zip-JBinding initialization procedure doesn't verify or overwrite temporary artifacts. This test
@@ -26,7 +27,7 @@ import net.sf.sevenzipjbinding.SevenZipNativeInitializationException;
  */
 public class InitializationDoesNotVerifyArtifactsTest {
     private static final String SYSTEM_PROPERTY_PHASE = "sevenziptest.standard_initialization_test_phase";
-    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+    private static final String TEMP_DIR = TestBase.getTempDir();
 
     @Test
     public void test() throws Exception {

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/StandardInitializationTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/StandardInitializationTest.java
@@ -9,6 +9,7 @@ import java.io.FileFilter;
 
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipNativeInitializationException;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import org.junit.Test;
  */
 public class StandardInitializationTest {
     private static final String SYSTEM_PROPERTY_PHASE = "sevenziptest.standard_initialization_test_phase";
-    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+    private static final String TEMP_DIR = TestBase.getTempDir();
 
     @Test
     public void test() throws SevenZipNativeInitializationException {

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/VersionTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/initialization/VersionTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.jar.Manifest;
 
 import org.junit.Test;
@@ -49,6 +50,23 @@ public class VersionTest extends JUnitNativeTestBase<VoidContext> {
     }
 
     private String getVersionFromJarMANIFEST() throws Exception {
+        if (System.getProperty("java.vendor", "unknown").equals("The Android Project")) {
+            String[] mf = SevenZip.SEVENZIPJBINDING_MANIFEST_MF.split(System.getProperty("line.separator", "\\n"));
+            HashMap<String, String> attributes = new HashMap<>();
+            for (String attr : mf) {
+                int index = attr.indexOf(": ");
+                String key = attr.substring(0, index);
+                String value = attr.substring(index + 2);
+                attributes.put(key, value);
+            }
+            String title = attributes.get("Implementation-Title");
+            if (title != null && title.startsWith("7-Zip-JBinding native lib")) {
+                String version = attributes.get("Implementation-Version");
+                if (version != null) {
+                    return version;
+                }
+            }
+        }
         Enumeration<URL> resources = getClass().getClassLoader().getResources("META-INF/MANIFEST.MF");
         while (resources.hasMoreElements()) {
             Manifest manifest = new Manifest(resources.nextElement().openStream());

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/misc/ArchiveWithTwoPasswordsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/misc/ArchiveWithTwoPasswordsTest.java
@@ -25,6 +25,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 import net.sf.sevenzipjbinding.util.ByteArrayStream;
 
@@ -78,7 +79,7 @@ public class ArchiveWithTwoPasswordsTest extends JUnitNativeTestBase<VoidContext
             TEST_DATA_PATH + "data2" //
     };
     private static final String[] DATA_PASSWORDS = { "data1", "data2" };
-    private static final String PASSWORD_PROTECTED_ARHCIVE = TEST_DATA_PATH + "two-passwords.7z";
+    private static final String PASSWORD_PROTECTED_ARHCIVE = TestBase.getFile(TEST_DATA_PATH + "two-passwords.7z");
     private static final ArchiveFormat ARCHIVE_FORMAT = ArchiveFormat.SEVEN_ZIP;
 
     @Test

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/multiplefiles/ExtractMultipleFileAbstractTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/multiplefiles/ExtractMultipleFileAbstractTest.java
@@ -11,6 +11,7 @@ import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.PropID;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.junit.ExtractFileAbstractTest;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.tools.ZipContentComparator;
 
 /**
@@ -85,7 +86,7 @@ public abstract class ExtractMultipleFileAbstractTest extends ExtractFileAbstrac
 	protected void doTestArchiveExtraction(int fileIndex, int compressionIndex, boolean autodetectFormat)
 			throws Exception {
 		String sollArchiveFilename = "archive" + fileIndex + ".zip";
-		String sollFullFilename = MULTIPLE_FILES_TEST_DATA_PATH + File.separatorChar + sollArchiveFilename;
+		String sollFullFilename = TestBase.getFile(MULTIPLE_FILES_TEST_DATA_PATH + File.separatorChar + sollArchiveFilename);
 
 		ExtractionInArchiveTestHelper extractionInArchiveTestHelper = new ExtractionInArchiveTestHelper();
 		closeLater(extractionInArchiveTestHelper);

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/multiplefiles/ExtractMultipleFileCabVolumeWithoutVolumedTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/multiplefiles/ExtractMultipleFileCabVolumeWithoutVolumedTest.java
@@ -16,6 +16,7 @@ import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
 import net.sf.sevenzipjbinding.junit.JUnitNativeTestBase;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.VoidContext;
 import net.sf.sevenzipjbinding.simple.ISimpleInArchive;
 import net.sf.sevenzipjbinding.simple.ISimpleInArchiveItem;
@@ -37,7 +38,7 @@ public class ExtractMultipleFileCabVolumeWithoutVolumedTest extends JUnitNativeT
 		IInArchive inArchive = null;
 		boolean ok = false;
 		try {
-			randomAccessFile = new RandomAccessFile("testdata/multiple-files/cab/vol-archive1.zip.0.disk1.cab", "r");
+			randomAccessFile = new RandomAccessFile(TestBase.getFile("testdata/multiple-files/cab/vol-archive1.zip.0.disk1.cab"), "r");
 			inArchive = SevenZip.openInArchive(useAutodetect ? null : ArchiveFormat.CAB, new RandomAccessFileInStream(
 					randomAccessFile));
 

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/singlefile/ExtractSingleFileAbstractTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/singlefile/ExtractSingleFileAbstractTest.java
@@ -22,6 +22,7 @@ import net.sf.sevenzipjbinding.ISequentialOutStream;
 import net.sf.sevenzipjbinding.PropID;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.junit.ExtractFileAbstractTest;
+import net.sf.sevenzipjbinding.junit.TestBase;
 import net.sf.sevenzipjbinding.junit.junittools.annotations.Multithreaded;
 import net.sf.sevenzipjbinding.junit.junittools.annotations.Repeat;
 
@@ -178,7 +179,7 @@ public abstract class ExtractSingleFileAbstractTest extends ExtractFileAbstractT
 	protected void doTestArchiveExtraction(int fileIndex, int compressionIndex, boolean autodetectFormat)
             throws Exception {
         String uncompressedFilename = getUncompressedFilename(fileIndex);
-        String expectedFilename = SINGLE_FILE_TEST_DATA_PATH + File.separatorChar + uncompressedFilename;
+        String expectedFilename = TestBase.getFile(SINGLE_FILE_TEST_DATA_PATH + File.separatorChar + uncompressedFilename);
 
         ExtractionInArchiveTestHelper extractionInArchiveTestHelper = new ExtractionInArchiveTestHelper();
         closeLater(extractionInArchiveTestHelper);

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressGenericTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressGenericTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 
 import net.sf.sevenzipjbinding.ArchiveFormat;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 import org.junit.Test;
 
@@ -64,7 +65,7 @@ public class CompressGenericTest extends SnippetTest {
     @Test
     public void testCompress7z() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed-generic.7z");
 
         beginSnippetTest();
@@ -77,7 +78,7 @@ public class CompressGenericTest extends SnippetTest {
     @Test
     public void testCompressZip() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed-generic.zip");
 
         beginSnippetTest();
@@ -90,7 +91,7 @@ public class CompressGenericTest extends SnippetTest {
     @Test
     public void testCompressTar() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed-generic.tar");
 
         beginSnippetTest();
@@ -103,7 +104,7 @@ public class CompressGenericTest extends SnippetTest {
     @Test
     public void testCompressGZip() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed-generic.gz");
 
         beginSnippetTest();
@@ -115,7 +116,7 @@ public class CompressGenericTest extends SnippetTest {
     @Test
     public void testCompressBZip2() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed-generic.bz2");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressMessageTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressMessageTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -28,7 +30,7 @@ public class CompressMessageTest extends SnippetTest {
     @Test
     public void testCompressMessage() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed_message.zip");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGeneric7zTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGeneric7zTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -28,7 +30,7 @@ public class CompressNonGeneric7zTest extends SnippetTest {
     @Test
     public void testCompress() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.7z");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericBZip2Test.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericBZip2Test.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -27,7 +29,7 @@ public class CompressNonGenericBZip2Test extends SnippetTest {
 
     @Test
     public void testCompress() {
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.bz2");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericGZipTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericGZipTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -27,7 +29,7 @@ public class CompressNonGenericGZipTest extends SnippetTest {
 
     @Test
     public void testCompress() {
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.gz");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericTarTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericTarTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -28,7 +30,7 @@ public class CompressNonGenericTarTest extends SnippetTest {
     @Test
     public void testCompress() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.tar");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericZipTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressNonGenericZipTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -28,7 +30,7 @@ public class CompressNonGenericZipTest extends SnippetTest {
     @Test
     public void testCompress() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.zip");
 
         beginSnippetTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressWithErrorTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/CompressWithErrorTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -56,7 +58,7 @@ public class CompressWithErrorTest extends SnippetTest {
     @Test
     public void testCompress() {
 
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "compressed.7z");
 
         beginSnippetFailingTest();

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/ExtractItemsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/ExtractItemsTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -32,7 +34,7 @@ public class ExtractItemsTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        ExtractItemsSimple.main(new String[] { "testdata/snippets/simple.zip" });
+        ExtractItemsSimple.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }
@@ -42,7 +44,7 @@ public class ExtractItemsTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        ExtractItemsStandard.main(new String[] { "testdata/snippets/simple.zip" });
+        ExtractItemsStandard.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }
@@ -52,7 +54,7 @@ public class ExtractItemsTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        ExtractItemsStandardCallback.main(new String[] { "testdata/snippets/simple.zip" });
+        ExtractItemsStandardCallback.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/FirstStepsSimpleSnippets.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/FirstStepsSimpleSnippets.java
@@ -9,12 +9,13 @@ import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.SevenZipException;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 import org.junit.Test;
 
 public class FirstStepsSimpleSnippets {
 
-    private static final String TEST_ARCHIVE_SIMPLE = "testdata/snippets/simple.zip";
+    private static final String TEST_ARCHIVE_SIMPLE = TestBase.getFile("testdata/snippets/simple.zip");
     private IInArchive inArchive;
     private RandomAccessFile randomAccessFile;
 

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/GetNumberOfItemInArchive.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/GetNumberOfItemInArchive.java
@@ -10,11 +10,12 @@ import net.sf.sevenzipjbinding.ArchiveFormat;
 import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.SevenZip;
 import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.junit.TestBase;
 
 public class GetNumberOfItemInArchive {
     @Test
     public void snippetRunner() throws Exception {
-        assertEquals(4, getNumberOfItemsInArchive("testdata/snippets/simple.zip"));
+        assertEquals(4, getNumberOfItemsInArchive(TestBase.getFile("testdata/snippets/simple.zip")));
     }
 
     /* BEGIN_SNIPPET(GetNumberOfItemsInArchive) */

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/ListItemsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/ListItemsTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -33,7 +35,7 @@ public class ListItemsTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        ListItemsStandard.main(new String[] { "testdata/snippets/simple.zip" });
+        ListItemsStandard.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }
@@ -43,7 +45,7 @@ public class ListItemsTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        ListItemsStandard.main(new String[] { "testdata/snippets/simple.zip" });
+        ListItemsStandard.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/OpenMultipartArchive7zTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/OpenMultipartArchive7zTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -33,7 +35,7 @@ public class OpenMultipartArchive7zTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        OpenMultipartArchive7z.main(new String[] { "testdata/snippets/multipart-7z.7z.001" });
+        OpenMultipartArchive7z.main(new String[] { TestBase.getFile("testdata/snippets/multipart-7z.7z.001") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/OpenMultipartArchiveRarTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/OpenMultipartArchiveRarTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -33,7 +35,7 @@ public class OpenMultipartArchiveRarTest extends SnippetTest {
         String expected = getExpectedOutput();
 
         beginSnippetTest();
-        OpenMultipartArchiveRar.main(new String[] { "testdata/snippets/multipart-rar.part1.rar" });
+        OpenMultipartArchiveRar.main(new String[] { TestBase.getFile("testdata/snippets/multipart-rar.part1.rar") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/PrintCountOfItemsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/PrintCountOfItemsTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -21,7 +23,7 @@ public class PrintCountOfItemsTest extends SnippetTest {
         expected = expected.replace("\n", NEW_LINE);
 
         beginSnippetTest();
-        PrintCountOfItems.main(new String[] { "testdata/snippets/simple.zip" });
+        PrintCountOfItems.main(new String[] { TestBase.getFile("testdata/snippets/simple.zip") });
         String output = endSnippetTest();
         assertEquals(expected, output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/UpdateAddRemoveItemsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/UpdateAddRemoveItemsTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -27,11 +29,11 @@ public class UpdateAddRemoveItemsTest extends SnippetTest {
 
     @Test
     public void testCompress7z() {
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "updated-add-remove-items.7z");
 
         beginSnippetTest();
-        UpdateAddRemoveItems.main(new String[] { "testdata/snippets/to-update.7z", archiveFile.getAbsolutePath() });
+        UpdateAddRemoveItems.main(new String[] { TestBase.getFile("testdata/snippets/to-update.7z"), archiveFile.getAbsolutePath() });
         String output = endSnippetTest();
         assertEquals(getExpectedOutput(expected7z), output);
     }

--- a/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/UpdateAlterItemsTest.java
+++ b/test/JavaTests/src/net/sf/sevenzipjbinding/junit/snippets/UpdateAlterItemsTest.java
@@ -1,5 +1,7 @@
 package net.sf.sevenzipjbinding.junit.snippets;
 
+import net.sf.sevenzipjbinding.junit.TestBase;
+
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -26,11 +28,11 @@ public class UpdateAlterItemsTest extends SnippetTest {
 
     @Test
     public void testCompress7z() {
-        String tmpDir = System.getProperty(SYSTEM_PROPERTY_TMP);
+        String tmpDir = TestBase.getTempDir();
         File archiveFile = new File(tmpDir, "updated-alter-items.7z");
 
         beginSnippetTest();
-        UpdateAlterItems.main(new String[] { "testdata/snippets/to-update.7z", archiveFile.getAbsolutePath() });
+        UpdateAlterItems.main(new String[] { TestBase.getFile("testdata/snippets/to-update.7z"), archiveFile.getAbsolutePath() });
         String output = endSnippetTest();
         assertEquals(getExpectedOutput(expected7z), output);
     }


### PR DESCRIPTION
For review. Please update as needed.
Unit tests not fully working on Android yet, further work still required. But would strongly recommend platform agnostic way to create temporary files and access the temporary directory (see class `TestBase`).