### PR TITLE
Prevent memory leak by deleting JNI local ref

### DIFF
--- a/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.cpp
+++ b/jbinding-cpp/CPPToJava/CPPToJavaArchiveExtractCallback.cpp
@@ -82,6 +82,7 @@ STDMETHODIMP CPPToJavaArchiveExtractCallback::GetStream(UInt32 index,
 
     CMyComPtr<ISequentialOutStream> outStreamComPtr = new CPPToJavaSequentialOutStream(
             _jbindingSession, jniEnvInstance, result);
+    jniEnvInstance->DeleteLocalRef(result);
     *outStream = outStreamComPtr.Detach();
 
     return S_OK;


### PR DESCRIPTION
While extracting archives, the streams used could not be garbage collected until the entire extract operation finished. This could be a problem when extracting large archives as the stream objects may eat all available heap space. This was fixed by deleting the JNI local ref shortly after creating the JNI global ref.